### PR TITLE
fix main search title

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -28,7 +28,7 @@ class SearchController < ApplicationController
       end
     end
 
-    @list_title = "Search Results for '#{params[:q]}'"
+    @all_list_title = "Search Results for '#{params[:q]}'"
 
     self.events
 

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -4,7 +4,7 @@
   </div>
   <br class="clearing">
 
-<h1><%= @list_title %></h1>
+<h1><%= @all_list_title %></h1>
 
 <ul class="nav nav-tabs">
   <li><a href="#event_results">Events</a></li>


### PR DESCRIPTION
Main search (for events and learners) contained the text 'learner'. I removed that for the initial search all page.
