### PR TITLE
Clean up error handling

### DIFF
--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -9,9 +9,8 @@ class WidgetsController < ApplicationController
 
   def generate_widget_snippet
     if params[:widget_params].nil?
-      returninformation = {'message' => 'We are missing the parameters we need to generate the widget code snippet', 'success' => false}
+      returninformation = {'message' => 'We are missing the parameters needed to generate the widget code snippet', 'success' => false}
       return render :json => returninformation.to_json, :status => :unprocessable_entity
-      # render :json => { :success => false }
     end
     @widget_key = params[:widget_key]
     @widget_url = widgets_events_url + ".js?" + params[:widget_params]
@@ -145,7 +144,7 @@ class WidgetsController < ApplicationController
     else
       # this method requires a widget_key param because that's how event.js.erb
       # locates the correct location in the dom to insert the widget.
-      returninformation = {'message' => 'We can not display the widget because the "widget key" parameter is missing.', 'success' => false}
+      returninformation = {'message' => 'We cannot display the example widget because the "widget key" parameter is missing.', 'success' => false}
       return render :json => returninformation.to_json, :status => :unprocessable_entity
     end
 

--- a/app/views/widgets/index.html.erb
+++ b/app/views/widgets/index.html.erb
@@ -90,14 +90,14 @@
       data: $("#widget_form").serialize()
     })
     .done(function(data) {
-      // The example widget displayed correctly so
-      // create the corresponding widget code snippet
+      // The example widget rendered without error so generate the corresponding widget code snippet
       generate_widget_snippet();
       $(".example-widget-container").hide().fadeIn();
     })
     .fail(function(json, responseText) {
       feedbackMessage = $.parseJSON(json.responseText).message
-      alert(feedbackMessage);
+      $(".example-widget-container").html("<p class='alert alert-danger'>"+feedbackMessage+"</p>");
+      generate_widget_snippet(); // clear out the code snippet by failing it
     })
   }
 
@@ -115,7 +115,7 @@
     })
     .fail(function(json, responseText) {
       feedbackMessage = $.parseJSON(json.responseText).message
-      alert(feedbackMessage);
+      $("#widget-code").html("<p class='alert alert-danger'>"+feedbackMessage+"</p>");
     })
   }
 


### PR DESCRIPTION
Present error messages more gracefully inline on the page and make the widget builder consistent with the Ask widget builder design.