### PR TITLE
Delete events

### DIFF
--- a/app/assets/stylesheets/all/events.css.scss
+++ b/app/assets/stylesheets/all/events.css.scss
@@ -38,7 +38,7 @@ color:#555;
 
 
 
-input[type="text"].edit-event-title {font-size:1.75em; height:auto; width: 90%;}
+input[type="text"].edit-event-title {font-size:1.5em; height:auto; }
 .edit-form {background:#eee; padding:2em;}
 
 span.related_events {padding-left:24px; display:block;}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,6 +54,10 @@ class ApplicationController < ActionController::Base
     render :file => "#{Rails.root}/public/404.html", :status => 404, :layout => false
   end
 
+  def do_410
+    render :template => "/shared/410", :status => 410
+  end
+
   private
 
   def set_timezone

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -138,6 +138,12 @@ class EventsController < ApplicationController
     @similar_events = @event.similar_events
     return if check_for_event_redirect
 
+    if (@event.is_deleted)
+      if (!current_learner || !current_learner.is_admin?)
+        do_410
+      end
+    end
+
     # there's a global time_zone setter - but we need to
     # do it again to make sure to force the time zone
     # display to the session and not the system default

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -40,6 +40,7 @@ class SearchController < ApplicationController
   def events
     events = Event.search do
                 with(:is_canceled, false)
+                with(:is_deleted, false)
                 fulltext(params[:q])
                 order_by(:session_start, :desc)
                 paginate :page => params[:page], :per_page => 10

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -15,152 +15,152 @@ class EventMailer < ActionMailer::Base
     @subject = options[:subject] || 'Your Weekly Learn Recommendations'
     @learner = @recommendation.learner
     @will_cache_email = options[:cache_email].nil? ? true : options[:cache_email]
-    
+
     if(!@learner.email.blank?)
       if(@will_cache_email)
         # create a cached mail object that can be used for "view this in a browser" within
         # the rendered email.
         @mailer_cache = MailerCache.create(learner: @learner, cacheable: @recommendation)
       end
-      
+
       return_email = mail(to: @learner.email, subject: @subject)
-      
+
       if(@mailer_cache)
         # now that we have the rendered email - update the cached mail object
         @mailer_cache.update_attribute(:markup, return_email.body.to_s)
       end
     end
-    
+
     # the email if we got it
     return_email
   end
-  
+
   def reminder(options = {})
     @event = options[:event]
     @subject = "Your Learn Event is Today"
-    @learner = options[:learner]  
+    @learner = options[:learner]
     @will_cache_email = options[:cache_email].nil? ? true : options[:cache_email]
-    
+
     if(!@learner.email.blank?)
       if(@will_cache_email)
         # create a cached mail object that can be used for "view this in a browser" within
         # the rendered email.
         @mailer_cache = MailerCache.create(learner: @learner, cacheable: @event)
       end
-      
+
       return_email = mail(to: @learner.email, subject: @subject)
-      
+
       if(@mailer_cache)
         # now that we have the rendered email - update the cached mail object
         @mailer_cache.update_attribute(:markup, return_email.body.to_s)
       end
     end
-    
+
     # the email if we got it
     return_email
   end
-  
+
   def recording(options = {})
     @event = options[:event]
     @subject = "A New Learn Recording is Available"
-    @learner = options[:learner]  
+    @learner = options[:learner]
     @will_cache_email = options[:cache_email].nil? ? true : options[:cache_email]
-    
+
     if(!@learner.email.blank?)
       if(@will_cache_email)
         # create a cached mail object that can be used for "view this in a browser" within
         # the rendered email.
         @mailer_cache = MailerCache.create(learner: @learner, cacheable: @event)
       end
-      
+
       return_email = mail(to: @learner.email, subject: @subject)
-      
+
       if(@mailer_cache)
         # now that we have the rendered email - update the cached mail object
         @mailer_cache.update_attribute(:markup, return_email.body.to_s)
       end
     end
-    
+
     # the email if we got it
     return_email
   end
-  
+
   def activity(options = {})
     @event = options[:event]
     @subject = "There's New Activity on One of Your Learn Events"
-    @learner = options[:learner]  
+    @learner = options[:learner]
     @will_cache_email = options[:cache_email].nil? ? true : options[:cache_email]
-    
+
     if(!@learner.email.blank?)
       if(@will_cache_email)
         # create a cached mail object that can be used for "view this in a browser" within
         # the rendered email.
         @mailer_cache = MailerCache.create(learner: @learner, cacheable: @event)
       end
-      
+
       return_email = mail(to: @learner.email, subject: @subject)
-      
+
       if(@mailer_cache)
         # now that we have the rendered email - update the cached mail object
         @mailer_cache.update_attribute(:markup, return_email.body.to_s)
       end
     end
-    
+
     # the email if we got it
     return_email
   end
-  
+
   def comment_reply(options = {})
     @comment = options[:comment]
     @event = @comment.event
     @subject = "There's a New Reply to One of Your Learn Comments"
-    @learner = options[:learner]  
+    @learner = options[:learner]
     @will_cache_email = options[:cache_email].nil? ? true : options[:cache_email]
-    
+
     if(!@learner.email.blank?)
       if(@will_cache_email)
         # create a cached mail object that can be used for "view this in a browser" within
         # the rendered email.
         @mailer_cache = MailerCache.create(learner: @learner, cacheable: @event)
       end
-      
+
       return_email = mail(to: @learner.email, subject: @subject)
-      
+
       if(@mailer_cache)
         # now that we have the rendered email - update the cached mail object
         @mailer_cache.update_attribute(:markup, return_email.body.to_s)
       end
     end
-    
+
     # the email if we got it
     return_email
   end
-  
+
   def event_edit(options = {})
     @event = options[:event]
     @subject = "There's Been a Change to One of Your Learn Events"
-    @learner = options[:learner]  
+    @learner = options[:learner]
     @will_cache_email = options[:cache_email].nil? ? true : options[:cache_email]
-    
+
     if(!@learner.email.blank?)
       if(@will_cache_email)
         # create a cached mail object that can be used for "view this in a browser" within
         # the rendered email.
         @mailer_cache = MailerCache.create(learner: @learner, cacheable: @event)
       end
-      
+
       return_email = mail(to: @learner.email, subject: @subject)
-      
+
       if(@mailer_cache)
         # now that we have the rendered email - update the cached mail object
         @mailer_cache.update_attribute(:markup, return_email.body.to_s)
       end
     end
-    
+
     # the email if we got it
     return_email
   end
-  
+
   def event_canceled(options = {})
     @event = options[:event]
     @learner = options[:learner]
@@ -168,26 +168,53 @@ class EventMailer < ActionMailer::Base
     @creator = @event.creator
     @last_modified_by = @event.last_modifier
     @will_cache_email = options[:cache_email].nil? ? true : options[:cache_email]
-    
+
     if(!@learner.email.blank?)
       if(@will_cache_email)
         # create a cached mail object that can be used for "view this in a browser" within
         # the rendered email.
         @mailer_cache = MailerCache.create(learner: @learner, cacheable: @event)
       end
-      
+
       return_email = mail(from: @last_modified_by.email, to: @learner.email, subject: @subject)
-      
+
       if(@mailer_cache)
         # now that we have the rendered email - update the cached mail object
         @mailer_cache.update_attribute(:markup, return_email.body.to_s)
       end
     end
-    
+
     # the email if we got it
     return_email
   end
-  
+
+  def event_deleted(options = {})
+    @event = options[:event]
+    @learner = options[:learner]
+    @subject = "An eXtension Learn Event has been deleted"
+    @creator = @event.creator
+    @last_modified_by = @event.last_modifier
+    @will_cache_email = options[:cache_email].nil? ? true : options[:cache_email]
+
+    if(!@learner.email.blank?)
+      if(@will_cache_email)
+        # create a cached mail object that can be used for "view this in a browser" within
+        # the rendered email.
+        @mailer_cache = MailerCache.create(learner: @learner, cacheable: @event)
+      end
+
+      return_email = mail(from: @last_modified_by.email, to: @learner.email, subject: @subject)
+
+      if(@mailer_cache)
+        # now that we have the rendered email - update the cached mail object
+        @mailer_cache.update_attribute(:markup, return_email.body.to_s)
+      end
+    end
+
+    # the email if we got it
+    return_email
+  end
+
   def event_rescheduled(options = {})
     @event = options[:event]
     @learner = options[:learner]
@@ -195,26 +222,26 @@ class EventMailer < ActionMailer::Base
     @creator = @event.creator
     @last_modified_by = @event.last_modifier
     @will_cache_email = options[:cache_email].nil? ? true : options[:cache_email]
-    
+
     if(!@learner.email.blank?)
       if(@will_cache_email)
         # create a cached mail object that can be used for "view this in a browser" within
         # the rendered email.
         @mailer_cache = MailerCache.create(learner: @learner, cacheable: @event)
       end
-      
+
       return_email = mail(from: @last_modified_by.email, to: @learner.email, subject: @subject)
-      
+
       if(@mailer_cache)
         # now that we have the rendered email - update the cached mail object
         @mailer_cache.update_attribute(:markup, return_email.body.to_s)
       end
     end
-    
+
     # the email if we got it
     return_email
   end
-  
+
   def event_location_changed(options = {})
     @event = options[:event]
     @learner = options[:learner]
@@ -222,26 +249,26 @@ class EventMailer < ActionMailer::Base
     @creator = @event.creator
     @last_modified_by = @event.last_modifier
     @will_cache_email = options[:cache_email].nil? ? true : options[:cache_email]
-    
+
     if(!@learner.email.blank?)
       if(@will_cache_email)
         # create a cached mail object that can be used for "view this in a browser" within
         # the rendered email.
         @mailer_cache = MailerCache.create(learner: @learner, cacheable: @event)
       end
-      
+
       return_email = mail(from: @last_modified_by.email, to: @learner.email, subject: @subject)
-      
+
       if(@mailer_cache)
         # now that we have the rendered email - update the cached mail object
         @mailer_cache.update_attribute(:markup, return_email.body.to_s)
       end
     end
-    
+
     # the email if we got it
     return_email
   end
-    
+
   def inform_iastate_new(options = {})
     @event = options[:event]
     @subject = "A new eXtension Learn Event has been created"
@@ -249,50 +276,50 @@ class EventMailer < ActionMailer::Base
     @presenter_emails = @event.presenters.map{|presenter| presenter.email}
     @cc_list = @presenter_emails.push(@creator.email).uniq
     @will_cache_email = options[:cache_email].nil? ? true : options[:cache_email]
-    
+
     if(!@creator.email.blank?)
       if(@will_cache_email)
         # create a cached mail object that can be used for "view this in a browser" within
         # the rendered email.
         @mailer_cache = MailerCache.create(learner: @event.creator, cacheable: @event)
       end
-      
+
       return_email = mail(from: @creator.email, to: Settings.iastate_support_email, cc: @cc_list, subject: @subject)
-      
+
       if(@mailer_cache)
         # now that we have the rendered email - update the cached mail object
         @mailer_cache.update_attribute(:markup, return_email.body.to_s)
       end
     end
-    
+
     # the email if we got it
     return_email
   end
-  
+
   def inform_iastate_update(options = {})
     @event = options[:event]
     @subject = "An eXtension Learn Event has been rescheduled"
     @creator = @event.creator
     @presenter_emails = @event.presenters.map{|presenter| presenter.email}
     @last_modified_by = @event.last_modifier
-    @cc_list = @presenter_emails.push(@creator.email).push(@last_modified_by.email).uniq  
+    @cc_list = @presenter_emails.push(@creator.email).push(@last_modified_by.email).uniq
     @will_cache_email = options[:cache_email].nil? ? true : options[:cache_email]
-    
+
     if(!@last_modified_by.email.blank?)
       if(@will_cache_email)
         # create a cached mail object that can be used for "view this in a browser" within
         # the rendered email.
         @mailer_cache = MailerCache.create(learner: @event.last_modifier, cacheable: @event)
       end
-      
+
       return_email = mail(from: @last_modified_by.email, to: Settings.iastate_support_email, cc: @cc_list, subject: @subject)
-      
+
       if(@mailer_cache)
         # now that we have the rendered email - update the cached mail object
         @mailer_cache.update_attribute(:markup, return_email.body.to_s)
       end
     end
-    
+
     # the email if we got it
     return_email
   end
@@ -303,72 +330,72 @@ class EventMailer < ActionMailer::Base
     @creator = @event.creator
     @presenter_emails = @event.presenters.map{|presenter| presenter.email}
     @last_modified_by = @event.last_modifier
-    @cc_list = @presenter_emails.push(@creator.email).push(@last_modified_by.email).uniq  
+    @cc_list = @presenter_emails.push(@creator.email).push(@last_modified_by.email).uniq
     @will_cache_email = options[:cache_email].nil? ? true : options[:cache_email]
-    
+
     if(!@last_modified_by.email.blank?)
       if(@will_cache_email)
         # create a cached mail object that can be used for "view this in a browser" within
         # the rendered email.
         @mailer_cache = MailerCache.create(learner: @event.last_modifier, cacheable: @event)
       end
-      
+
       return_email = mail(from: @last_modified_by.email, to: Settings.iastate_support_email, cc: @cc_list, subject: @subject)
-      
+
       if(@mailer_cache)
         # now that we have the rendered email - update the cached mail object
         @mailer_cache.update_attribute(:markup, return_email.body.to_s)
       end
     end
-    
+
     # the email if we got it
     return_email
   end
-  
+
   def learner_retired(options = {})
     @learner = options[:learner]
     @subject = "A Learner's account has been retired"
     @will_cache_email = options[:cache_email].nil? ? true : options[:cache_email]
-    
+
     if(!@learner.email.blank?)
       if(@will_cache_email)
         # create a cached mail object that can be used for "view this in a browser" within
         # the rendered email.
         @mailer_cache = MailerCache.create(learner: @learner, cacheable: @event)
       end
-      
+
       return_email = mail(to: Settings.engineering_list, subject: @subject)
-      
+
       if(@mailer_cache)
         # now that we have the rendered email - update the cached mail object
         @mailer_cache.update_attribute(:markup, return_email.body.to_s)
       end
     end
-    
+
     # the email if we got it
     return_email
   end
-  
+
   def mailtest(options = {})
     @subject = "This is a test of the Learn Email System."
-    @learner = options[:learner]  
+    @learner = options[:learner]
     @will_cache_email = options[:cache_email].nil? ? true : options[:cache_email]
-    
+
     if(!@learner.email.blank?)
       if(@will_cache_email)
         # create a cached mail object that can be used for "view this in a browser" within
         # the rendered email.
         @mailer_cache = MailerCache.create(learner: @learner, cacheable: @event)
       end
-      
+
       return_email = mail(to: @learner.email, subject: @subject)
-      
+
       if(@mailer_cache)
         # now that we have the rendered email - update the cached mail object
         @mailer_cache.update_attribute(:markup, return_email.body.to_s)
       end
     end
-    
+
     # the email if we got it
     return_email
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -481,6 +481,15 @@ class Event < ActiveRecord::Base
         Notification.create(notifiable: self, notificationtype: Notification::EVENT_RESCHEDULED, delivery_time: Notification::RESCHEDULED_NOTIFICATION_INTERVAL.from_now) unless Notification.pending_rescheduled_notification?(self)
       end
     end
+    if self.is_deleted_changed?
+      if self.is_deleted?
+        Notification.create(notifiable: self, notificationtype: Notification::CANCELED_IASTATE, delivery_time: 1.minute.from_now) if self.is_connect_session?
+        Notification.create(notifiable: self, notificationtype: Notification::EVENT_DELETED, delivery_time: 1.minute.from_now)
+      else
+        Notification.create(notifiable: self, notificationtype: Notification::UPDATE_IASTATE, delivery_time: 1.minute.from_now) if self.is_connect_session?
+        Notification.create(notifiable: self, notificationtype: Notification::EVENT_RESCHEDULED, delivery_time: Notification::RESCHEDULED_NOTIFICATION_INTERVAL.from_now) unless Notification.pending_rescheduled_notification?(self)
+      end
+    end
   end
 
   def set_featured_at

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -17,7 +17,7 @@ class Event < ActiveRecord::Base
 
   # define accessible attributes
   attr_accessible :creator, :last_modifier
-  attr_accessible :title, :description, :session_length, :location, :recording, :presenter_tokens, :tag_list, :session_start_string, :time_zone, :is_expired, :is_canceled
+  attr_accessible :title, :description, :session_length, :location, :recording, :presenter_tokens, :tag_list, :session_start_string, :time_zone, :is_expired, :is_canceled, :is_deleted
   attr_accessible :conference, :conference_id, :room, :event_type, :presenter_ids, :is_broadcast, :featured, :featured_at, :evaluation_link
   attr_accessible :material_links_attributes
   attr_accessible :images_attributes
@@ -100,13 +100,14 @@ class Event < ActiveRecord::Base
     text :presenter_names
     boolean :is_canceled
     boolean :is_expired
+    boolean :is_deleted
   end
 
   scope :bookmarked, include: :event_connections, conditions: ["event_connections.connectiontype = ?", EventConnection::BOOKMARK]
   scope :attended, include: :event_connections, conditions: ["event_connections.connectiontype = ?", EventConnection::ATTEND]
   scope :watched, include: :event_connections, conditions: ["event_connections.connectiontype = ?", EventConnection::WATCH]
 
-  scope :active, conditions: {is_canceled: false}
+  scope :active, conditions: {is_canceled: false, is_deleted: false}
   scope :not_expired, conditions: {is_expired: false}
   scope :featured, conditions: {featured: true}
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -30,7 +30,7 @@ class Notification < ActiveRecord::Base
   def process
     return true if !Settings.send_notifications
 
-    if (self.notifiable_type == 'Event') && (Event.find_by_id(self.notifiable_id).is_canceled == true) && (self.notificationtype != EVENT_CANCELED or self.notificationtype != CANCELED_IASTATE)
+    if (self.notifiable_type == 'Event') && (Event.find_by_id(self.notifiable_id).is_canceled == true) && (self.notificationtype != EVENT_CANCELED and self.notificationtype != CANCELED_IASTATE)
       return true
     end
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,5 +1,5 @@
 class Notification < ActiveRecord::Base
-  
+
   #belongs_to :event
   belongs_to :notifiable, :polymorphic => true
   after_create :queue_delayed_notifications
@@ -12,6 +12,7 @@ class Notification < ActiveRecord::Base
   EVENT_CANCELED = 4
   EVENT_RESCHEDULED = 5
   EVENT_LOCATION_CHANGE = 6
+  EVENT_DELETED = 7
   ACTIVITY = 10
   COMMENT_REPLY = 11
   ACTIVITY_NOTIFICATION_INTERVAL = Settings.activity_notification_interval
@@ -23,15 +24,16 @@ class Notification < ActiveRecord::Base
   UPDATE_IASTATE = 41
   CANCELED_IASTATE = 42
   LEARNER_RETIRED = 50
-  
-  
+
+
+
   def process
     return true if !Settings.send_notifications
-    
+
     if (self.notifiable_type == 'Event') && (Event.find_by_id(self.notifiable_id).is_canceled == true) && (self.notificationtype != EVENT_CANCELED or self.notificationtype != CANCELED_IASTATE)
       return true
     end
-    
+
     case self.notificationtype
     when EVENT_REMINDER_EMAIL
       process_event_reminder_emails
@@ -43,6 +45,8 @@ class Notification < ActiveRecord::Base
       process_event_canceled
     when EVENT_RESCHEDULED
       process_event_rescheduled
+    when EVENT_DELETED
+      process_event_deleted
     when EVENT_LOCATION_CHANGE
       process_event_location_change
     when ACTIVITY
@@ -65,37 +69,37 @@ class Notification < ActiveRecord::Base
       # nothing
     end
   end
-  
+
   def process_event_reminder_emails
-    self.notifiable.learners.each{|learner| EventMailer.reminder(learner: learner, event: self.notifiable).deliver unless (learner.email.blank? or !learner.send_reminder? or learner.has_event_notification_exception?(self.notifiable))}      
+    self.notifiable.learners.each{|learner| EventMailer.reminder(learner: learner, event: self.notifiable).deliver unless (learner.email.blank? or !learner.send_reminder? or learner.has_event_notification_exception?(self.notifiable))}
   end
 
   def process_event_reminder_sms
-    self.notifiable.learners.each{|learner| send_sms_notification(learner) unless (learner.email.blank? or !learner.send_sms?(self.offset) or learner.has_event_notification_exception?(self.notifiable))}      
-  end  
+    self.notifiable.learners.each{|learner| send_sms_notification(learner) unless (learner.email.blank? or !learner.send_sms?(self.offset) or learner.has_event_notification_exception?(self.notifiable))}
+  end
 
   def process_activity_notifications
-    self.notifiable.learners.each{|learner| EventMailer.activity(learner: learner, event: self.notifiable).deliver unless (learner.email.blank? or !learner.send_activity? or learner.has_event_notification_exception?(self.notifiable))}      
+    self.notifiable.learners.each{|learner| EventMailer.activity(learner: learner, event: self.notifiable).deliver unless (learner.email.blank? or !learner.send_activity? or learner.has_event_notification_exception?(self.notifiable))}
   end
-  
+
   #still need to implement email
   def process_recording_notifications
-    self.notifiable.learners.each{|learner| EventMailer.recording(learner: learner, event: self.notifiable).deliver unless (learner.email.blank? or !learner.send_recording? or learner.has_event_notification_exception?(self.notifiable))}      
+    self.notifiable.learners.each{|learner| EventMailer.recording(learner: learner, event: self.notifiable).deliver unless (learner.email.blank? or !learner.send_recording? or learner.has_event_notification_exception?(self.notifiable))}
   end
-  
+
   def process_comment_reply
     comment = self.notifiable
     learner = comment.parent.learner
     event = self.notifiable.event
     EventMailer.comment_reply(learner: learner, comment: comment).deliver unless (learner.email.blank? or !learner.send_activity? or learner.has_event_notification_exception?(event))
   end
-  
+
   def process_event_edit
     learner = self.notifiable.creator
     event= self.notifiable
     EventMailer.event_edit(learner: learner, event: event).deliver unless (learner.email.blank? or !learner.send_reminder? or learner.has_event_notification_exception?(event))
   end
-  
+
   def process_event_canceled
     event = self.notifiable
     if !event.started?
@@ -104,21 +108,30 @@ class Notification < ActiveRecord::Base
       EventMailer.inform_iastate_canceled(event: event).deliver
     end
   end
-  
+
   def process_event_rescheduled
     event = self.notifiable
     if !event.started?
       event.learners.each{|learner| EventMailer.event_rescheduled(learner: learner, event: event).deliver unless (learner.email.blank? or !learner.send_rescheduled_or_canceled? or learner.has_event_notification_exception?(event))}
-    end    
+    end
   end
-  
+
+  def process_event_deleted
+    event = self.notifiable
+    if !event.started?
+      event.learners.each{|learner| EventMailer.event_deleted(learner: learner, event: event).deliver unless (learner.email.blank? or !learner.send_rescheduled_or_canceled? or learner.has_event_notification_exception?(event))}
+      EventMailer.event_deleted(learner: Learner.learnbot, event: event).deliver
+      EventMailer.inform_iastate_canceled(event: event).deliver
+    end
+  end
+
   def process_event_location_change
     event = self.notifiable
     if !event.started?
       event.learners.each{|learner| EventMailer.event_location_changed(learner: learner, event: event).deliver unless (learner.email.blank? or !learner.send_location_change? or learner.has_event_notification_exception?(event))}
     end
   end
-  
+
   def process_recommendation
     recommendation = self.notifiable
     # doublecheck delivery setting
@@ -126,7 +139,7 @@ class Notification < ActiveRecord::Base
       EventMailer.recommendation(recommendation: recommendation).deliver
     end
   end
-  
+
   def process_inform_iastate
     event = self.notifiable
     EventMailer.inform_iastate_new(event: event).deliver unless event.started?
@@ -136,36 +149,36 @@ class Notification < ActiveRecord::Base
     event = self.notifiable
     EventMailer.inform_iastate_update(event: event).deliver unless event.started?
   end
-  
+
   def process_canceled_iastate
     event = self.notifiable
     EventMailer.inform_iastate_canceled(event: event).deliver unless event.started?
   end
-  
+
   def process_learner_retired
     learner = self.notifiable
     EventMailer.learner_retired(learner: learner).deliver
   end
-  
+
   def queue_delayed_notifications
     delayed_job = Delayed::Job.enqueue(NotificationJob.new(self.id), {:priority => 0, :run_at => self.delivery_time})
     self.update_attribute(:delayed_job_id, delayed_job.id)
   end
-  
+
   def update_delivery_time(delivery_time)
     self.update_attribute(:delivery_time, delivery_time - self.offset)
   end
-  
+
   def update_delayed_notifications
       delayed_job = Delayed::Job.find_by_id(self.delayed_job_id)
       delayed_job.update_attributes(:run_at => self.delivery_time) if !delayed_job.nil?
   end
-  
+
   def sms_message(learner)
     "\"#{self.notifiable.title.truncate(80, separator: ' ')}\" is starting soon! #{self.notifiable.session_start_for_learner(learner).strftime("%I:%M%p %Z")} @ #{Settings.urlwriter_host}/events/#{self.notifiable.id}"
   end
-  
-  
+
+
   def send_sms_notification(learner)
     if !learner.mobile_number.blank?
       uri = URI(Settings.tropo_url)
@@ -178,17 +191,17 @@ class Notification < ActiveRecord::Base
       end
     end
   end
-  
+
   def self.pending_activity_notification?(notifiable)
     Notification.where(notifiable_id: notifiable.id, notificationtype: ACTIVITY, delivery_time: Time.now..ACTIVITY_NOTIFICATION_INTERVAL.from_now).size > 0
   end
-  
+
   def self.pending_rescheduled_notification?(notifiable)
     Notification.where(notifiable_id: notifiable.id, notificationtype: EVENT_RESCHEDULED, delivery_time: Time.now..RESCHEDULED_NOTIFICATION_INTERVAL.from_now).size > 0
   end
-  
+
   def self.pending_location_change_notification?(notifiable)
     Notification.where(notifiable_id: notifiable.id, notificationtype: EVENT_LOCATION_CHANGE, delivery_time: Time.now..LOCATION_CHANGE_NOTIFICATION_INTERVAL.from_now).size > 0
   end
-  
+
 end

--- a/app/views/event_mailer/event_deleted.html.erb
+++ b/app/views/event_mailer/event_deleted.html.erb
@@ -65,7 +65,7 @@
     </th>
   </tr>
   <tr class="tagline">
-    <td>Learn Event Canceled</td>
+    <td>Learn Event Deleted</td>
   </tr>
   <tr class="options">
     <td>
@@ -81,10 +81,10 @@
   <tr><td>
     <table cellpadding="0" cellspacing="0" border="0" align="center" width="500">
       <tr>
-        <td id="reminder_title"><%= @event.title -%> has been deleted</td>
+        <td id="reminder_title">The Learn event "<%= @event.title -%>" has been deleted.</td>
       </tr>
       <tr>
-        <td id="reminder_description"><%= @last_modified_by.name %> deleted this event. </td>
+        <td id="reminder_description">The event was deleted by <%= @last_modified_by.name %>.</td>
       </tr>
     </table>
 
@@ -95,7 +95,7 @@
       <table cellpadding="0" cellspacing="0" border="0" align="center" width="100%" class="footer">
         <tr>
           <td class="bgcolor">
-            <p>This email was sent to you because you are connected with this event.</p>
+            <p>This email was sent to you because you were connected with this event.</p>
           </td>
         </tr>
         <tr class="options">

--- a/app/views/event_mailer/event_deleted.html.erb
+++ b/app/views/event_mailer/event_deleted.html.erb
@@ -65,7 +65,7 @@
     </th>
   </tr>
   <tr class="tagline">
-    <td>Connect Session Canceled</td>
+    <td>Learn Event Canceled</td>
   </tr>
   <tr class="options">
     <td>

--- a/app/views/event_mailer/event_deleted.html.erb 
+++ b/app/views/event_mailer/event_deleted.html.erb 
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+
+<html style="margin: 0; padding: 0;">
+
+<head>
+  <title>
+    Learn Event Deleted
+  </title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no" />
+  <style type="text/css">
+  body {margin:0 auto; padding:10px; background:#f5f5f5;}
+  #wrapper {
+    -webkit-box-shadow: rgba(0,0,0,.4) 0 3px 10px;
+    margin:20px;
+    -webkit-border-radius: 10px;
+    background:#fff;
+    width:599px;
+  }
+	a:hover { text-decoration: none !important; }
+	h1 {color: #d98837 !important; font: normal 30px Georgia, serif; margin: 0 0 0 10px; padding: 0; line-height: 40px;}
+	tr.tagline  {background:#000; color:#fff; padding:10px;}
+	tr.demotagline td  {background:#FF0; color:#000; padding:10px; font: normal 20px Arial, Verdana, sans-serif; text-align:center;}
+	tr.tagline td  {background:#000; color:#fff; padding:10px; font: normal 20px Arial, Verdana, sans-serif;}
+	tr.options  {background:#585858; color:#fff; padding:10px;}
+	tr.options td  {background:#585858; color:#ddd; padding:5px 9px;}
+	tr.options td a {color:#aaa; padding:6px; font: normal 14px  Arial, Verdana, sans-serif; text-decoration:none;}
+	tr.options td a:hover {color:#fff;}
+	tr.date td {font: normal 12px  Arial, Verdana, sans-serif; text-align:center; padding:15px 10px; color:#888; text-transform:uppercase;}
+	.article h3 {font: bold 24px  Georgia, serif; margin: 0;}
+	.article p {font: normal 14px  Arial, sans-serif; margin: 20px 0 0; margin:0 0 0; line-height:18px;}
+	.article td {padding:10px;}
+	.footer td {padding:10px;}
+	table.footer {margin:0 0 30px;}
+	table.footer p {color:#888; font: normal 13px  Arial, sans-serif;}
+	table.footer tr.options td {color:#888; font: normal 13px  Arial, sans-serif; background:#fff; padding:0 5px;}
+	table.footer tr.options td a {color:#0069D6; font: normal 13px  Arial, sans-serif; background:#fff;}
+	td.footer {padding-top:1em;}
+	#learn_logo {height: 96px;}
+	.bgcolor {background:#fff;}
+	#reminder_title {font: bold 20px Arial, Verdana, sans-serif; padding:1.5em 0 .75em;}
+	#reminder_title a {color:#000; text-decoration:none;}
+	#event_start_time {font: normal 20px Arial, Verdana, sans-serif; padding:.65em; background:#e5e5e5;}
+	#event_start_time strong {font-size:28px;}
+	#event_start_time a {color:#000; text-decoration:none;}
+	#button a {color:#0069D6; padding:.5em .75em; text-decoration:none; font: bold 22px Arial, Verdana, sans-serif;}
+	#reminder_description {padding-top:1.5em;}
+	.clock {padding-right:1em;}
+	</style>
+	<%= stylesheet_link_tag("#{ssl_root_url}email/mobile.css") %>
+</head>
+<body>
+
+
+<div id="wrapper" class="bgcolor">
+<table cellpadding="0" cellspacing="0" border="0" align="center" width="599" class="bgcolor">
+  <%- if Settings.app_location != 'production' -%>
+    <tr class="demotagline">
+      <td>This email is being sent from a demonstration install of Learn. Please feel free to ignore this test email.</td>
+    </tr>
+  <%- end -%>
+  <tr>
+    <th align="left" class="bgcolor">
+      <%- logo_url = @mailer_cache.blank? ? "#{ssl_root_url}assets/logo_small.png" : "#{ssl_webmail_logo}" -%>
+      <h1 id="learn_logo"><%= image_tag(logo_url, alt: "Learn") %></h1>
+    </th>
+  </tr>
+  <tr class="tagline">
+    <td>Connect Session Canceled</td>
+  </tr>
+  <tr class="options">
+    <td>
+      <%- if @mailer_cache -%>
+        <%= link_to('View in a browser', webmail_view_url(hashvalue: @mailer_cache.hashvalue)) %>
+      <%- else -%>
+        <a href="">View in a browser</a>
+      <%- end -%>
+      <%= link_to "Unsubscribe", settings_notifications_url() %>
+    </td>
+  </tr>
+
+  <tr><td>
+    <table cellpadding="0" cellspacing="0" border="0" align="center" width="500">
+      <tr>
+        <td id="reminder_title"><%= @event.title -%> has been deleted</td>
+      </tr>
+      <tr>
+        <td id="reminder_description"><%= @last_modified_by.name %> deleted this event. </td>
+      </tr>
+    </table>
+
+  </td></tr>
+
+  <tr>
+    <td class="footer">
+      <table cellpadding="0" cellspacing="0" border="0" align="center" width="100%" class="footer">
+        <tr>
+          <td class="bgcolor">
+            <p>This email was sent to you because you are connected with this event.</p>
+          </td>
+        </tr>
+        <tr class="options">
+          <td>
+            <%- if @mailer_cache -%>
+              <%= link_to('View in a browser', webmail_view_url(hashvalue: @mailer_cache.hashvalue)) %>
+            <%- else -%>
+              <a href="">View in a browser</a>
+            <%- end -%>
+            <%= link_to "Unsubscribe", settings_notifications_url() %>
+          </td>
+        </tr>
+        <tr><td>&nbsp;</td></tr>
+      </table>
+    </td>
+  </tr>
+</table>
+</div>
+</body>
+</html>

--- a/app/views/events/_conference_event_form.html.erb
+++ b/app/views/events/_conference_event_form.html.erb
@@ -1,3 +1,5 @@
+<%= form_for @event, :html => {:multipart => true} do |event_form| -%>
+
 <%= hidden_field_tag 'event[conference_id]', @event.conference_id %>
 <%= hidden_field_tag 'event[time_zone]', @event.time_zone %>
 
@@ -147,7 +149,7 @@
 
   </fieldset>
 <% end %>
-
+<%- end -%>
 
 <p>
   <%= submit_tag 'Save Session', :class => "btn btn-default btn-primary btn-lg" %>

--- a/app/views/events/_online_event_form.html.erb
+++ b/app/views/events/_online_event_form.html.erb
@@ -1,3 +1,5 @@
+<%= form_for @event, :html => {:multipart => true} do |event_form| -%>
+
 <fieldset id="event-title">
   <p>
     <%= event_form.text_field :title, :size => nil, :class => "form-control edit-event-title" %>
@@ -127,41 +129,23 @@
   </div>
 </fieldset>
 
- <!-- While an event is going on, you can neither cancel it nor expire it -->
- <!-- Admins can cancel and expire events anytime -->
- <% if (!@event.new_record? && !@event.started?) || (current_learner.is_admin && !@event.new_record?) %>
-   <fieldset>
-      <p class="clearing">
-        <label>
-        <%= event_form.check_box :is_canceled %>
-        Cancel this Event
-        <span class="help-block">The event page is still viewable. A "Canceled" banner is displayed on the page, and an email is sent to people who followed the event. Please update the "description" field explaining why the event was canceled. The event will eventually be removed from the site.</span>
-        </label>
-      </p>
-   </fieldset>
- <% end %>
-
- <% if (!@event.new_record? && @event.concluded?) || (current_learner.is_admin && !@event.new_record?) %>
-   <fieldset>
-     <p class="clearing">
-       <label>
-       <%= event_form.check_box :is_expired %>
-       Expire this Event
-       <span class="help-block">Use this option when an event is out-of-date or the technical recording is poor. A prominent "expired" banner is displayed on the page, and the event is removed from our recommendation engine. Please update the "description" field explaining why, and include a link to a better session if available.</span>
-       </label>
-     </p>
-
-  </fieldset>
-<% end %>
-
 <p>
-  <%= submit_tag 'Save Session', :class => "btn btn-default btn-primary btn-lg" %>
+  <%= submit_tag 'Save', :class => "btn btn-default btn-primary btn-lg" %>
   <%- if @event.id %>
     <%= link_to("cancel", event_path(@event.id), :class => "cancel") -%>
   <%- else -%>
     <%= link_to("cancel", root_path(), :class => "cancel") -%>
   <%- end -%>
 </p>
+
+
+
+<%- end -%>
+
+
+
+
+
 
  <script class="code" type="text/javascript">
    $('#session_start').datetimepicker({

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -9,16 +9,85 @@
   </div>
 <%- end -%>
 
-<div class="edit-form col-md-10">
-  <h1>Edit this event</h1>
-  <%= form_for @event, :html => {:multipart => true} do |form| -%>
-    <%- if @event.conference -%>
-      <%= render(partial: 'conference_event_form', locals: {event_form: form}) %>
-    <%- else -%>
-      <%= render(partial: 'online_event_form', locals: {event_form: form}) %>
-    <%- end -%>
+<div class="edit-form col-md-9">
+  <h1>Edit event</h1>
+
+  <%- if @event.conference -%>
+    <%= render(partial: 'conference_event_form') %>
+  <%- else -%>
+    <%= render(partial: 'online_event_form') %>
   <%- end -%>
+
 </div>
+
+<div class="col-md-3">
+  <div class="well">
+  <h4>Special Actions</h4>
+
+  <p><a class="btn btn-default btn-link" data-toggle="collapse" href="#collapseCancel" aria-expanded="false" aria-controls="collapseCancel">Cancellation</a></p>
+
+  <div class="collapse" id="collapseCancel">
+
+    <!-- While an event is going on, you can neither cancel it nor expire it -->
+    <!-- Admins can cancel and expire events anytime -->
+    <% if (!@event.new_record? && !@event.started?) || (current_learner.is_admin && !@event.new_record?) %>
+      <%= form_for @event, :html => {:multipart => true} do |event_form| -%>
+
+          <p>
+            <label>
+              <%= event_form.check_box :is_canceled %>
+              Cancel Event
+              <span class="help-block">The event page is still viewable. A "Canceled" banner is displayed on the page, and an email is sent to people who followed the event. Please update the "description" field explaining why the event was canceled.</span>
+            </label>
+          </p>
+          <%- if @event.is_canceled -%>
+            <p><%= submit_tag 'Update Cancellation Status', :class => "btn btn-default btn-danger" %></p>
+          <%- else -%>
+          <p><%= submit_tag 'Cancel Event', :class => "btn btn-default btn-danger" %></p>
+          <%- end -%>
+          <% end %>
+
+
+          <% else %>
+
+    <p>This event cannot be cancelled because it's already taken place or is currently in progress. </p>
+   <% end %>
+
+  </div>
+
+  <p><a class="btn btn-default btn-link" data-toggle="collapse" href="#collapseExpire" aria-expanded="false" aria-controls="collapseExpire">Expiration</a></p>
+
+  <div class="collapse" id="collapseExpire">
+
+    <% if (!@event.new_record? && @event.concluded?) || (current_learner.is_admin && !@event.new_record?) %>
+      <%= form_for @event, :html => {:multipart => true} do |event_form| -%>
+      <fieldset>
+        <p class="clearing">
+          <label>
+          <%= event_form.check_box :is_expired %>
+          Expire Event
+          <span class="help-block">Use this option when an event is out-of-date or the technical recording is poor. A prominent "expired" banner is displayed on the page, and the event is removed from our recommendation engine. Please update the "description" field explaining why, and include a link to a better session if available.</span>
+          </label>
+        </p>
+        <p><%= submit_tag 'Expire Event', :class => "btn btn-default btn-danger" %></p>
+     </fieldset>
+     <% end %>
+  <% else %>
+    <p>This event cannot be marked as expired because it hasn't taken place yet.</p>
+   <% end %>
+
+  </div>
+
+
+
+</div>
+</div>
+
+
+
+
+
+
 
 
 <script type="text/javascript">

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -36,7 +36,7 @@
            <p><%= submit_tag 'Remove the expired warning', :class => "btn btn-default" %></p>
          <%- else -%>
            <%= event_form.hidden_field :is_expired, value: true %>
-           <h4>Expire Event</h4>
+           <h4>Expire event</h4>
            <p class="help-block">When an event is out-of-date or the technical recording is poor. An "expired" banner is displayed, and the event is removed from our recommendations. Please update the "description" field explaining why, and include a link to a better session if available.</p>
            <p><%= submit_tag 'Expire event', :class => "btn btn-default btn-warning" %></p>
          <%- end -%>
@@ -57,7 +57,7 @@
           <p><%= submit_tag 'Make this event active', :class => "btn btn-default" %></p>
         <%- else -%>
           <%= event_form.hidden_field :is_canceled, value: true %>
-          <h4>Cancel Event</h4>
+          <h4>Cancel event</h4>
           <p class="help-block">The event page remains viewable, a "canceled" banner is displayed, and an email is sent to people who followed the event. Please update the "description" field explaining why.</p>
           <p><%= submit_tag 'Cancel event', :class => "btn btn-default btn-danger" %></p>
         <%- end -%>
@@ -77,7 +77,7 @@
         <%- else -%>
           <h4>Delete event</h4>
           <%= event_form.hidden_field :is_deleted, value: true %>
-          <p class="help-block">The event is removed, and the event page displays a 404. If the event needs to be recovered, please contact an eXtension staff member for help.</p>
+          <p class="help-block">The event page displays a 404, and an email is sent to people who followed the event. If the event needs to be recovered, please contact an eXtension staff member for help.</p>
           <p><%= submit_tag 'Delete event', :class => "btn btn-default btn-danger" %></p>
         <%- end -%>
       <% end %>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -21,95 +21,69 @@
 </div>
 
 <div class="col-md-3">
-  <div class="well">
   <h4>Special Actions</h4>
 
-  <p><a class="btn btn-default btn-link" data-toggle="collapse" href="#collapseCancel" aria-expanded="false" aria-controls="collapseCancel">Cancellation</a></p>
+  <p><a class="btn btn-default" data-toggle="collapse" href="#collapseSpecials" aria-expanded="false" aria-controls="collapseSpecials">View cancel, delete or expire options</a></p>
 
-  <div class="collapse" id="collapseCancel">
+  <div class="collapse" id="collapseSpecials">
 
+    <div class="well">
+     <% if (!@event.new_record? && @event.concluded?) || (current_learner.is_admin && !@event.new_record?) %>
+       <%= form_for @event, :html => {:multipart => true} do |event_form| -%>
+         <%- if @event.is_expired -%>
+           <%= event_form.hidden_field :is_expired, value: false %>
+           <h4>This event is expired.</h4>
+           <p><%= submit_tag 'Remove the expired warning', :class => "btn btn-default" %></p>
+         <%- else -%>
+           <%= event_form.hidden_field :is_expired, value: true %>
+           <h4>Expire Event</h4>
+           <p class="help-block">When an event is out-of-date or the technical recording is poor. An "expired" banner is displayed, and the event is removed from our recommendations. Please update the "description" field explaining why, and include a link to a better session if available.</p>
+           <p><%= submit_tag 'Expire event', :class => "btn btn-default btn-warning" %></p>
+         <%- end -%>
+      <% end %>
+     <% else %>
+       <p>This event cannot be marked as expired because it hasn't taken place yet.</p>
+     <% end %>
+   </div>
+
+    <div class="well">
     <!-- While an event is going on, you can neither cancel it nor expire it -->
     <!-- Admins can cancel and expire events anytime -->
     <% if (!@event.new_record? && !@event.started?) || (current_learner.is_admin && !@event.new_record?) %>
       <%= form_for @event, :html => {:multipart => true} do |event_form| -%>
-
-          <p>
-            <label>
-              <%= event_form.check_box :is_canceled %>
-              Cancel Event
-              <span class="help-block">The event page is still viewable. A "Canceled" banner is displayed on the page, and an email is sent to people who followed the event. Please update the "description" field explaining why the event was canceled.</span>
-            </label>
-          </p>
-          <%- if @event.is_canceled -%>
-            <p><%= submit_tag 'Update Cancellation Status', :class => "btn btn-default btn-danger" %></p>
-          <%- else -%>
-          <p><%= submit_tag 'Cancel Event', :class => "btn btn-default btn-danger" %></p>
-          <%- end -%>
-          <% end %>
-
-
-          <% else %>
-
-    <p>This event cannot be cancelled because it's already taken place or is currently in progress. </p>
+        <%- if @event.is_canceled -%>
+        <%= event_form.hidden_field :is_canceled, value: false %>
+          <h4>This event is canceled.</h4>
+          <p><%= submit_tag 'Make this event active', :class => "btn btn-default" %></p>
+        <%- else -%>
+          <%= event_form.hidden_field :is_canceled, value: true %>
+          <h4>Cancel Event</h4>
+          <p class="help-block">The event page remains viewable, a "canceled" banner is displayed, and an email is sent to people who followed the event. Please update the "description" field explaining why.</p>
+          <p><%= submit_tag 'Cancel event', :class => "btn btn-default btn-danger" %></p>
+        <%- end -%>
+      <% end %>
+    <% else %>
+      <p>This event cannot be cancelled because it's already taken place or is currently in progress. </p>
    <% end %>
+   </div>
 
-  </div>
-
-
-
-  <p><a class="btn btn-default btn-link" data-toggle="collapse" href="#collapseExpire" aria-expanded="false" aria-controls="collapseExpire">Expiration</a></p>
-
-  <div class="collapse" id="collapseExpire">
-
-    <% if (!@event.new_record? && @event.concluded?) || (current_learner.is_admin && !@event.new_record?) %>
-      <%= form_for @event, :html => {:multipart => true} do |event_form| -%>
-      <fieldset>
-        <p class="clearing">
-          <label>
-          <%= event_form.check_box :is_expired %>
-          Expire Event
-          <span class="help-block">Use this option when an event is out-of-date or the technical recording is poor. A prominent "expired" banner is displayed on the page, and the event is removed from our recommendation engine. Please update the "description" field explaining why, and include a link to a better session if available.</span>
-          </label>
-        </p>
-        <p><%= submit_tag 'Expire Event', :class => "btn btn-default btn-danger" %></p>
-     </fieldset>
-     <% end %>
-  <% else %>
-    <p>This event cannot be marked as expired because it hasn't taken place yet.</p>
-   <% end %>
-
-  </div>
-
-
-
-
-  <p><a class="btn btn-default btn-link" data-toggle="collapse" href="#collapseDelete" aria-expanded="false" aria-controls="collapseDelete">Delete event</a></p>
-
-  <div class="collapse" id="collapseDelete">
-
-
+  <div class="well">
     <% if (!@event.new_record?) || (current_learner.is_admin && !@event.new_record?) %>
       <%= form_for @event, :html => {:multipart => true} do |event_form| -%>
-
-          <p>
-            <label>
-              <%= event_form.check_box :is_deleted %>
-              Delete Event
-              <span class="help-block">The event is removed, and the event page displays a 404. If the event needs to be recovered, please contact an eXtension staff member for help.</span>
-            </label>
-          </p>
-          <%- if @event.is_deleted -%>
-            <p><%= submit_tag 'Update Delete Status', :class => "btn btn-default btn-danger" %></p>
-          <%- else -%>
-          <p><%= submit_tag 'Delete Event', :class => "btn btn-default btn-danger" %></p>
-          <%- end -%>
-          <% end %>
-
-
-          <% else %>
-
-    <p>This event cannot be deleted because it's currently in progress.</p>
-   <% end %>
+        <%- if @event.is_deleted -%>
+          <h4>This event is deleted.</h4>
+          <%= event_form.hidden_field :is_deleted, value: false %>
+          <p><%= submit_tag 'Make this event active', :class => "btn btn-default" %></p>
+        <%- else -%>
+          <h4>Delete event</h4>
+          <%= event_form.hidden_field :is_deleted, value: true %>
+          <p class="help-block">The event is removed, and the event page displays a 404. If the event needs to be recovered, please contact an eXtension staff member for help.</p>
+          <p><%= submit_tag 'Delete event', :class => "btn btn-default btn-danger" %></p>
+        <%- end -%>
+      <% end %>
+    <% else %>
+      <p>This event cannot be deleted because it's currently in progress.</p>
+    <% end %>
 
   </div>
 

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -55,6 +55,8 @@
 
   </div>
 
+
+
   <p><a class="btn btn-default btn-link" data-toggle="collapse" href="#collapseExpire" aria-expanded="false" aria-controls="collapseExpire">Expiration</a></p>
 
   <div class="collapse" id="collapseExpire">
@@ -78,6 +80,38 @@
 
   </div>
 
+
+
+
+  <p><a class="btn btn-default btn-link" data-toggle="collapse" href="#collapseDelete" aria-expanded="false" aria-controls="collapseDelete">Delete event</a></p>
+
+  <div class="collapse" id="collapseDelete">
+
+
+    <% if (!@event.new_record?) || (current_learner.is_admin && !@event.new_record?) %>
+      <%= form_for @event, :html => {:multipart => true} do |event_form| -%>
+
+          <p>
+            <label>
+              <%= event_form.check_box :is_deleted %>
+              Delete Event
+              <span class="help-block">The event is removed, and the event page displays a 404. If the event needs to be recovered, please contact an eXtension staff member for help.</span>
+            </label>
+          </p>
+          <%- if @event.is_deleted -%>
+            <p><%= submit_tag 'Update Delete Status', :class => "btn btn-default btn-danger" %></p>
+          <%- else -%>
+          <p><%= submit_tag 'Delete Event', :class => "btn btn-default btn-danger" %></p>
+          <%- end -%>
+          <% end %>
+
+
+          <% else %>
+
+    <p>This event cannot be deleted because it's currently in progress.</p>
+   <% end %>
+
+  </div>
 
 
 </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -4,19 +4,26 @@
 <%- @page_type = "event" -%>
 <%- @noindex = false -%>
 
-
 <%- if @event.is_expired -%>
   <%- @noindex = true -%>
-  <div id="outofdate">
+  <div class="alert alert-warning">
     <h1>This event is expired. It is not recommended for technical reasons or is out of date.</h1>
     <h2>Please check the event description below for more details</h2>
   </div>
 <%- end -%>
 
 
+<%- if @event.is_deleted -%>
+  <div class="alert alert-danger">
+    <h1>This event has been deleted</h1>
+    <p>This content below can only be seen by eXtension admin accounts. Everyone else sees a "Page Removed" message.</p>
+  </div>
+  <div id="deleted_wrapper">
+<%- end -%>
+
 
 <%- if @event.is_canceled -%>
-  <div id="event_status">
+<div class="alert alert-danger">
     <h1>This event has been canceled</h1>
     <h2>Please check the event description below for more details</h2>
   </div>
@@ -32,38 +39,38 @@
 
 
 <script class="code" type="text/javascript">
-  $('.submittable').live('change', 
+  $('.submittable').live('change',
     function() {
       $(this).parents('form:first').submit();
     }
-  );  
+  );
 
   $(document).ready(function() {
 
     // sitv = sign in to vote
     $('.nojs_display').hide();
-    
+
     $('.sitv_element_wrapper').each(function(index) {
       var $sitv_element = $(this).find('.sitv_element')
       var $h = $sitv_element.outerHeight();
       var $w = $sitv_element.outerWidth();
       $(this).find('.sitv_targetarea').height($h).width($w);
     });
-    
+
     $('.sitv_targetarea').bind('click', function () {
       $(this).siblings('.sitv_content').fadeIn('fast');
     });
-    
+
     $('.sitv_content').mouseleave(function() {
       $(this).fadeOut('fast');
     });
-    
-    
-    
-    
+
+
+
+
     $('.addtocal').AddToCal({
       getEventDetails: function( element ) {
-        var 
+        var
           dtstart_element = element.find('.dtstart'),
           dtend_element = element.find('.dtend'),
           title_element = element.find('.summary'),
@@ -72,15 +79,15 @@
           url_vcs_element = element.find('.vcs_url');
 
         // return the required event structure
-        return { 
+        return {
           webcalurl: null,
           icalurl: url_ics_element.html(),
-          vcalurl: url_vcs_element.html(), 
-          start: dtstart_element.html(), 
-          end: dtend_element.html(), 
-          title: title_element.html(), 
-          details: details_element.html(), 
-          location: null, 
+          vcalurl: url_vcs_element.html(),
+          start: dtstart_element.html(),
+          end: dtend_element.html(),
+          title: title_element.html(),
+          details: details_element.html(),
+          location: null,
           url: null
         };
       },

--- a/app/views/shared/410.html.erb
+++ b/app/views/shared/410.html.erb
@@ -1,0 +1,9 @@
+<div class="row">
+  <div class="col-md-offset-1 col-md-10">
+		<div class="page-header">
+			<h1>Page Removed</h1>
+		</div>
+		<p>The requested page has been removed from our server. Please visit the <%= link_to "homepage", root_path %> to find other Learn events.</p>
+
+	</div>
+</div>

--- a/db/migrate/20150520204212_add_deleted_flag_to_events.rb
+++ b/db/migrate/20150520204212_add_deleted_flag_to_events.rb
@@ -1,0 +1,5 @@
+class AddDeletedFlagToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :is_deleted, :boolean, :null => false, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150224184639) do
+ActiveRecord::Schema.define(:version => 20150520204212) do
 
   create_table "activity_logs", :force => true do |t|
     t.integer  "learner_id",                  :null => false
@@ -180,6 +180,7 @@ ActiveRecord::Schema.define(:version => 20150224184639) do
     t.integer  "raters_count",                           :default => 0,        :null => false
     t.integer  "commentators_count",                     :default => 0,        :null => false
     t.text     "provided_presenter_order"
+    t.boolean  "is_deleted",                             :default => false,    :null => false
   end
 
   add_index "events", ["conference_id"], :name => "conference_ndx"


### PR DESCRIPTION
There has been a request to be able to delete events which were created for testing. The cancel option didn't quite meet this need, so we're adding a delete option

* Add the ability to delete an event
* Return a 410 code (Gone)
* admin eXtension accounts can view deleted events and make them active again 
* Group all the special actions (expire, cancel, delete) together to improve the UI
