### PR TITLE
Remove duplicated form tag

### DIFF
--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -12,15 +12,11 @@
 <div class="edit-form col-md-8">
   <%- if @event.conference -%>
     <h1>Create a conference event</h1>
-    <%= form_for @event,  :html => { :class => "form-stacked"} do |form| -%>
-      <%= render(partial: 'conference_event_form', locals: {event_form: form}) %>
-    <%- end -%>
+      <%= render(partial: 'conference_event_form') %>
   <%- else -%>
 
   <h1>Create an event</h1>
-  <%= form_for @event,  :html => { :class => "form-stacked"} do |form| -%>
-    <%= render(partial: 'online_event_form', locals: {event_form: form}) %>
-  <%- end -%>
+    <%= render(partial: 'online_event_form') %>
 <%- end -%>
 </div>
 


### PR DESCRIPTION
This fixes a bug where cover images failed to upload during the creation of new events. 

On the /events/new view, a valid multipart form is rendered in a partial, but the partial was wrapped in a non-multipart form tag which was overriding the correctly constructed form in the DOM, resulting in an image upload failure (a NULL value).