### PR TITLE
Registration ui tweaks

### DIFF
--- a/app/assets/stylesheets/all/events.css.scss
+++ b/app/assets/stylesheets/all/events.css.scss
@@ -1,4 +1,7 @@
 @import "_variables";
+.registration-location {padding:10px; background:#fff;}
+.registration-location-note {padding:10px; background: #fff6bf;}
+.registration-url {display:block; font-family:monospace;font-size:16px;color:blue;}
 .event-audience {font-size:14px; color:#888; margin:1em 0 1em;}
 
 .event-learners {padding:20px; background:#eee; clear:left; margin-top:0;}

--- a/app/controllers/learners_controller.rb
+++ b/app/controllers/learners_controller.rb
@@ -129,7 +129,7 @@ class LearnersController < ApplicationController
       end
       session[:registration_modal] = true
       session[:registration_email] = @registation.email
-      redirect_to(event_path(@event))
+      redirect_to(event_path(@event), :notice => "Thank you. An email has been sent to #{session[:registration_email]} with your registration.")
     end
   end
 

--- a/app/controllers/learners_controller.rb
+++ b/app/controllers/learners_controller.rb
@@ -129,7 +129,7 @@ class LearnersController < ApplicationController
       end
       session[:registration_modal] = true
       session[:registration_email] = @registation.email
-      redirect_to(event_path(@event), :notice => "Thank you. An email has been sent to #{session[:registration_email]} with your registration.")
+      redirect_to(event_path(@event), :notice => "Thank you. A confirmation email has been sent to #{session[:registration_email]}.")
     end
   end
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -234,24 +234,6 @@
 <br class='clearing' />
 </div>
 
-<!-- Registration Modal -->
-<div class="modal fade" id="registration-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-        <h4 class="modal-title">Registration Notice!</h4>
-      </div>
-      <div class="modal-body">
-        Thank you for registering for this event. Return to this page at the time of the live event to enter the room. An email has been sent to <b><%= session[:registration_email] %></b> with information about your registration.
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-      </div>
-    </div><!-- /.modal-content -->
-  </div><!-- /.modal-dialog -->
-</div><!-- /.modal -->
-
 
 <%- if @event.is_canceled -%>
   <br class='clearing' />
@@ -260,11 +242,6 @@
 
 
 <script class="code" type="text/javascript">
-
-  <%- if session[:registration_modal] == true -%>
-    $('#registration-modal').modal('show');
-    <%- session[:registration_modal] = false -%>
-  <%- end -%>
 
   $('.submittable').live('change',
     function() {

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -175,7 +175,13 @@
           <%= render :partial => 'registration' %>
         <%- end -%>
 
-        <p class="location"><small><strong>Location:</strong> <%= auto_link(@event.location.html_safe, :all, :target => "_blank") -%></small></p>
+        <div class="location registration-location">
+          <p>
+            <strong>Webinar URL:</strong>
+            <span class="registration-url"><%= auto_link(@event.location.html_safe, :all, :target => "_blank") -%></span>
+          </p>
+          <p class="registration-location-note"><strong>Note</strong>: <strong>The above URL might change</strong>. When it's time for the webinar to begin, please visit this page to get the correct URL.</p>
+        </div>
 
       <%-end -%>
 
@@ -183,22 +189,10 @@
     </aside>
 
     <%- if current_learner -%>
-
       <aside id="eventconnections" class="event-connections radius10">
         <%= render :partial => 'connections' %>
       </aside>
-
-
-    <%- else -%>
-       <aside id="eventconnections" class="event-connections radius10 placeholder">
-          <%- if @event.started? -%>
-            <p>Did you attend or watch this event or want to follow it? <%= link_to("Sign in to connect to this event", signin_path()) -%></p>
-          <%- else -%>
-            <p><%= link_to("Sign in to follow this event", signin_path()) -%></p>
-          <%- end -%>
-          <br class="clearing" />
-       </aside>
-     <%- end -%>
+    <%- end -%>
 
      <div class="event-tags">
        <div class="tags">

--- a/app/views/home/contact_us.html.erb
+++ b/app/views/home/contact_us.html.erb
@@ -1,26 +1,25 @@
+<% @page_title = 'Contact Us' %>
+
 <div class="col-md-8">
-  <h1>Contact us</h1>
 
-<!-- Ask an Expert widget -->
-<script type="text/javascript">
-  (function() {
-    function async_load(){
-      var aae = document.createElement('script'); aae.type = 'text/javascript'; aae.async = true;
-      aae.src = "https://ask.extension.org/groups/1278/ask_widget.js";
-      var s = document.getElementsByTagName('script')[0];s.parentNode.insertBefore(aae, s);
-    }
-    if (window.attachEvent)
-      window.attachEvent('onload', async_load);
-    else
-      window.addEventListener('load', async_load, false);
-  })();
-</script>
-<div id="aae-1278"></div>
-<!-- End Ask an Expert widget -->
+  <h2>Contact Us</h2>
 
 
 
+
+    <h3>Have a question about this application?</h3>
+<p>We'd love to help! Email us a bug report at <a href="mailto:contact-us@extension.org">contact-us@extension.org</a></p>
+
+<p>A great bug/issue report includes:
+  <ul>
+    <li>What you wanted to do. (As much specific detail as possible!)</li>
+    <li>What you expected to happen.</li>
+    <li>What actually happened</li>
+    <li>Uploading a screen capture of any error messages, or the browser window you see is fantastic!</li>
+  </ul>
+</p>
 
   <h3>Want to know more about eXtension?</h3>
-  <p>Visit <a href="http://about.extension.org">About eXtension</a>.  There you'll find links to various eXtension resources where you can learn more about the benefits of eXtension, discover how to get involved with your colleagues already participating,  or get started with the eXtension sites and services.</p>
+  <p>Visit <a href="https://www.extension.org/">extension.org</a>.  There you'll find links to various eXtension resources where you can learn more about the benefits of eXtension, discover how to get involved with your colleagues already participating,  or get started with the eXtension sites and services.</p>
+
 </div>


### PR DESCRIPTION
- The registration notification has been moved from a modal a standard feedback banner
- Post-registration URL is more prominent, with a line of text advising that the URL might change
- The "Sign in to connect with this event" link has been removed
- Contact Us page updated