### PR TITLE
Remove references to deleted learner_activities table

### DIFF
--- a/app/models/activity_log.rb
+++ b/app/models/activity_log.rb
@@ -13,7 +13,5 @@ class ActivityLog < ActiveRecord::Base
   validates :loggable, :presence => true
 
   scope :event_activity_records, conditions: {'loggable_type' => 'EventActivity'}
-  scope :learner_activity_records, conditions: {'loggable_type' => 'LearnerActivity'}
-
 
 end

--- a/app/models/learner.rb
+++ b/app/models/learner.rb
@@ -13,8 +13,6 @@ class Learner < ActiveRecord::Base
   mount_uploader :avatar, AvatarUploader
 
   has_many :activity_logs, dependent: :destroy
-  has_many :learner_activities, dependent: :destroy
-  has_many :learner_activities_as_recipient, :class_name => "LearnerActivity", :foreign_key => 'recipient_id'
   has_many :created_events, :class_name => "Event", :foreign_key => 'creator_id'
   has_many :modified_events, :class_name => "Event", :foreign_key => 'last_modifier_id'
   has_many :event_connections, dependent: :destroy


### PR DESCRIPTION
- this was causing the Learner.destroy method to fail: "NameError: uninitialized constant Learner::LearnerActivity"